### PR TITLE
RenderCore_Minimal: use glSubTexImage2d over glTexImage2d

### DIFF
--- a/lib/RenderCore_Minimal/rendercore.cpp
+++ b/lib/RenderCore_Minimal/rendercore.cpp
@@ -74,7 +74,7 @@ void RenderCore::Render( const ViewPyramid& view, const Convergence converge, bo
 	}
 	// copy pixel buffer to OpenGL render target texture
 	glBindTexture( GL_TEXTURE_2D, targetTextureID );
-	glTexImage2D( GL_TEXTURE_2D, 0, GL_RGBA, screen->width, screen->height, 0, GL_RGBA, GL_UNSIGNED_BYTE, screen->pixels );
+	glTexSubImage2D( GL_TEXTURE_2D, 0, GL_RGBA, screen->width, screen->height, 0, GL_RGBA, GL_UNSIGNED_BYTE, screen->pixels );
 }
 
 //  +-----------------------------------------------------------------------------+


### PR DESCRIPTION
This prevents a new allocation of texture memory and as a result is likely faster.

Extra info:
https://www.khronos.org/opengl/wiki/Common_Mistakes#Updating_a_texture

```
glTexImage2D creates the storage for the texture, defining the size/format and removing all previous pixel data. glTexSubImage2D only modifies pixel data within the texture. It can be used to update all the texels, or simply a portion of them.
```