### PR TITLE
Fix optix7 bug causing access violations

### DIFF
--- a/lib/rendercore_optix7/rendercore.cpp
+++ b/lib/rendercore_optix7/rendercore.cpp
@@ -515,7 +515,7 @@ void RenderCore::SetMaterials( CoreMaterial* mat, const int materialCount )
 	if (materialBuffer == 0 || materialCount > materialBuffer->GetSize())
 	{
 		delete hostMaterialBuffer;
-	hostMaterialBuffer = new CUDAMaterial[materialCount];
+		hostMaterialBuffer = new CUDAMaterial[materialCount + 512];
 	}
 	for (int i = 0; i < materialCount; i++)
 	{
@@ -556,9 +556,11 @@ void RenderCore::SetMaterials( CoreMaterial* mat, const int materialCount )
 		// just set the new material data
 		materialBuffer->SetHostData( hostMaterialBuffer );
 	}
-	else /* if (materialCount > materialBuffer->GetSize()) */
+	else if (materialCount > materialBuffer->GetSize())
 	{
 		// TODO: realloc, remove +512 during allocation
+		delete materialBuffer;
+		materialBuffer = new CoreBuffer<CUDAMaterial>( materialCount + 512, ON_HOST | ON_DEVICE | STAGED, hostMaterialBuffer );
 	}
 	materialBuffer->StageCopyToDevice();
 	stageMaterialList( materialBuffer->DevPtr() );


### PR DESCRIPTION
in `void RenderCore::SetMaterials( CoreMaterial* mat, const int materialCount )` under `RenderCore_Optix7`, the `hostMaterialBuffer` is initialized with size `materialCount`, but `materialBuffer` has size `materialCount` and attribute `ON_DEVICE` set.

This triggers `if (location & ON_DEVICE) CopyToDevice();` and eventually performs memcpy with size `(materialCount + 512) * sizeof(CUDAMaterial)`, which can occationally trigger access violation during tinyapp startup.

Thanks for the project, and please see if this patch helps.