### PR TITLE
Remove dead link from comments, addressing issue #33

### DIFF
--- a/lib/platform/platform.cpp
+++ b/lib/platform/platform.cpp
@@ -3094,7 +3094,6 @@ static void find_coreGL( void )
 {
 
 	/* Thank you @elmindreda
-	 * https://github.com/elmindreda/greg/blob/master/templates/greg.c.in#L176
 	 * https://github.com/glfw/glfw/blob/master/src/context.c#L36
 	 */
 	int i, major, minor;


### PR DESCRIPTION
This pull request removes a deprecated hyperlink from the source code comments that led to an archived 'greg' repository, which is no longer maintained or available. The removal aligns with the information provided in issue #33 and avoids potential confusion for developers referencing the code.